### PR TITLE
PR[3.2]docs: add fetcher documentation

### DIFF
--- a/docs/dev_docs/fetcher.md
+++ b/docs/dev_docs/fetcher.md
@@ -1,0 +1,12 @@
+# Fetcher
+
+The fetcher is used to pull whitelisted files/folders from one or more git repositories. It takes a string containing 3 values:  
+1. A URL to a git based repository
+2. A branch name
+3. A path to a whitelist file  
+These can be repeated in the string as shown below for multiple fetches
+```go
+func FetchFiles(url, branch, specFile string) error 
+```
+
+The fetcher caches fetched CSV files in a folder named `cache`. The caching works for any folder depth so long as a CSV file is present

--- a/docs/user_docs/fetcher_usage.md
+++ b/docs/user_docs/fetcher_usage.md
@@ -1,0 +1,20 @@
+# Fetcher Usage
+
+To fetch a file from a repository you can run the following command
+For single repo fetch:
+```bash
+./Tech_Radar_<OS> --fetch "<Url> <Branch> <Whitelist_Filepath>"
+```
+For multiple repos:
+```bash
+./Tech_Radar_<OS> --fetch "<Url> <Branch> <Whitelist_Filepath> <Url_1> <Branch_1> <Whitelist_Filepath_1>"
+```
+*The Url must be a valid public git repository otherwise it will not work*
+
+The whitelist file should be a file containing filepaths to either files or folders you would like the fetcher to grab e.g.
+```
+/path
+/root/test.csv
+/usr/bin
+```
+


### PR DESCRIPTION
This was missing from the fetcher PR that got merged
Adds to: #41 #45 #44